### PR TITLE
Update migrant

### DIFF
--- a/bin/migrant
+++ b/bin/migrant
@@ -10,8 +10,10 @@
 $autoLoader = false;
 
 $files = [
-	__DIR__ . '/../../../autoload.php', // composer dependency
-	__DIR__ . '/../vendor/autoload.php' // stand-alone package
+	__DIR__ . '/../autoload.php', // composer dependency (called from /vendor/bin dir)
+	__DIR__ . '/../../../autoload.php', // composer dependency (called from /vendor/fluxoft/migrant/bin - not recommended)
+	__DIR__ . '/../vendor/autoload.php', // stand-alone package (assuming one level deep, e.g. /migrations)
+	__DIR__ . '/../vendor/autoload.php' // stand-alone package (assuming two levels deep, e.g. /deploy/db)
 ];
 
 foreach ($files as $file) {


### PR DESCRIPTION
This change fixes a bug where running this file from the /vendor/bin folder wasn't finding the composer autoload file. This was obscured because during testing I was calling this from that folder, but my migrations folder was in <root>/db which worked the same as finding the autoload as if it was a standalone package. This fixes that problem.
